### PR TITLE
Recover delegate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ adlg_mac64
 # System Files
 .DS_Store
 Thumbs.db
+
+### IntelliJ IDEA ###
+.idea

--- a/deleg.go
+++ b/deleg.go
@@ -59,6 +59,12 @@ func getMinString(bigStr string) string {
 
 // делегирование
 func delegate() {
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Println("Delegate recovered after err: ", r)
+		}
+	}()
+
 	var err error
 	for iS, _ := range accs {
 		var valueBuy map[string]float32


### PR DESCRIPTION
Немного неприятно, что в apiGetAddress.go в методе 

```
// узнаем баланс и количество транзакций
func (c *SDK) GetAddress(usrAddr string) (map[string]float32, uint32, error) {
```

наряду с возвратом ошибки есть еще и просто паника:
```
err = data.UnmarshalJSON(body)
  if err != nil {
    panic(err)
  }
```
из за этого периодически отваливается adeleg.

Как решение добавил recover:

```
// делегирование
func delegate() {
  defer func() {
    if r := recover(); r != nil {
      fmt.Println("Delegate recovered after err: ", r)
    }
  }()
```
